### PR TITLE
Beginnings of create noun ui

### DIFF
--- a/backend/DB.ts
+++ b/backend/DB.ts
@@ -1,5 +1,5 @@
 import Umzug from "umzug";
-import s from "sequelize";
+import s, { Sequelize as SequelizeType } from "sequelize";
 import ss from "umzug/lib/storages/SequelizeStorage.js";
 import { router } from "./Router.js";
 // @ts-ignore
@@ -8,7 +8,7 @@ import db from "../models/index.cjs";
 const { default: SequelizeStorage } = ss;
 const { Sequelize } = s;
 
-export const sequelize = db.sequelize;
+export const sequelize: SequelizeType = db.sequelize;
 
 export const dbReady = new Promise<void>((resolve, reject) => {
   const intervalId = setInterval(() => {

--- a/backend/Server.ts
+++ b/backend/Server.ts
@@ -17,21 +17,14 @@ app.listen(port);
 const fullUrl = `http://localhost:${port}`;
 console.log(`Listening on ${fullUrl}`);
 
-// For debugging concurrently + nodemon problems
 // https://github.com/remy/nodemon/issues/1247
-console.log("---------------");
-console.log("STARTING PID", process.pid);
-console.log("---------------");
-
 const pid = process.pid;
 process.on("SIGINT", function () {
-  console.log("---------------");
-  console.log("KILLING PID", process.pid);
-  console.log("---------------");
   kill(pid, "SIGTERM");
   process.exit();
 });
 
 if (process.env.NODE_ENV !== "production" && process.env.FLAX_OPEN === "true") {
+  delete process.env.FLAX_OPEN;
   open(fullUrl);
 }

--- a/backend/Server.ts
+++ b/backend/Server.ts
@@ -3,6 +3,8 @@ import { router } from "./Router.js";
 import bodyParser from "body-parser";
 import "./DB.js";
 import "./RouteImports.js";
+import kill from "tree-kill";
+import open from "open";
 
 const app = express();
 app.use(bodyParser.json());
@@ -12,4 +14,24 @@ const port = process.env.PORT || 7600;
 
 app.listen(port);
 
-console.log(`Listening on http://localhost:${port}`);
+const fullUrl = `http://localhost:${port}`;
+console.log(`Listening on ${fullUrl}`);
+
+// For debugging concurrently + nodemon problems
+// https://github.com/remy/nodemon/issues/1247
+console.log("---------------");
+console.log("STARTING PID", process.pid);
+console.log("---------------");
+
+const pid = process.pid;
+process.on("SIGINT", function () {
+  console.log("---------------");
+  console.log("KILLING PID", process.pid);
+  console.log("---------------");
+  kill(pid, "SIGTERM");
+  process.exit();
+});
+
+if (process.env.NODE_ENV !== "production" && process.env.FLAX_OPEN === "true") {
+  open(fullUrl);
+}

--- a/backend/WebApp/WebApp.ts
+++ b/backend/WebApp/WebApp.ts
@@ -16,6 +16,9 @@ router.use(async (req, res: Response) => {
     );
   } catch (err) {
     console.log("ERROR", err);
+    return res.status(500).json({
+      errors: `Failed to generate HTML`,
+    });
   }
 
   if (routerContext.url) {

--- a/backend/WebApp/WebApp.ts
+++ b/backend/WebApp/WebApp.ts
@@ -1,14 +1,25 @@
+import { Response } from "express";
 import { router } from "../Router.js";
 import { createElement } from "react";
 import ReactDOMServer from "react-dom/server.js";
-import { App } from "../../frontend/App.js";
+import { App, RouterContext } from "../../frontend/App.js";
 
-router.use(async (req, res) => {
-  let stream;
+router.use(async (req, res: Response) => {
+  let stream,
+    routerContext: RouterContext = {};
   try {
-    stream = ReactDOMServer.renderToNodeStream(createElement(App));
+    stream = ReactDOMServer.renderToNodeStream(
+      createElement(App, {
+        routerContext,
+        reqUrl: req.url,
+      })
+    );
   } catch (err) {
     console.log("ERROR", err);
+  }
+
+  if (routerContext.url) {
+    return res.redirect(routerContext.url);
   }
 
   stream.on("error", (err) => {

--- a/backend/nouns/PostNouns.ts
+++ b/backend/nouns/PostNouns.ts
@@ -1,17 +1,47 @@
+import { body, validationResult } from "express-validator";
+import { ModelCtor } from "sequelize/lib/model.js";
+import { NounModel } from "../../models/noun.js";
 import { sequelize } from "../DB.js";
 import { router } from "../Router.js";
 
-router.post("/api/nouns", async (req, res) => {
-  const { tableName, slug, friendlyName, parentId } = req.body;
-  const newNoun = await sequelize.models.Noun.create({
-    tableName,
-    slug,
-    friendlyName,
-    parentId,
-  });
-  if (newNoun) {
-    res.status(201).send(newNoun);
-  } else {
-    res.status(500);
+router.post(
+  "/api/nouns",
+  body("tableName").isString().notEmpty(),
+  async (req, res) => {
+    const validationErrors = validationResult(req);
+
+    if (!validationErrors.isEmpty()) {
+      return res.status(400).json({
+        errors: validationErrors.array(),
+      });
+    }
+
+    const { tableName, slug, friendlyName, parentId } = req.body;
+
+    const Nouns: ModelCtor<NounModel> = sequelize.models.Noun;
+
+    const { count: numDuplicates } = await Nouns.findAndCountAll({
+      where: {
+        tableName,
+      },
+    });
+
+    if (numDuplicates > 0) {
+      return res.status(400).send({
+        error: `A noun with tableName ${tableName} already exists`,
+      });
+    }
+
+    const newNoun = await sequelize.models.Noun.create({
+      tableName,
+      slug,
+      friendlyName,
+      parentId,
+    });
+    if (newNoun) {
+      res.status(201).send(newNoun);
+    } else {
+      res.status(500);
+    }
   }
-});
+);

--- a/backend/nouns/PostNouns.ts
+++ b/backend/nouns/PostNouns.ts
@@ -1,4 +1,4 @@
-import { body, validationResult } from "express-validator";
+import { body, checkSchema, validationResult } from "express-validator";
 import { ModelCtor } from "sequelize/lib/model.js";
 import { NounModel } from "../../models/noun.js";
 import { sequelize } from "../DB.js";
@@ -7,6 +7,9 @@ import { router } from "../Router.js";
 router.post(
   "/api/nouns",
   body("tableName").isString().notEmpty(),
+  body("slug").isString().notEmpty(),
+  body("friendlyName").isString().notEmpty(),
+  body("parentId").isInt().optional({ nullable: true }),
   async (req, res) => {
     const validationErrors = validationResult(req);
 

--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -1,23 +1,31 @@
-import * as React from "react";
-import { Button } from "semantic-ui-react";
+import { StaticRouter, Route, Redirect } from "react-router";
+import { BrowserRouter } from "react-router-dom";
+import { CreateNoun } from "./Nouns/CreateNoun";
+import { QueryClient, QueryClientProvider } from "react-query";
 
-export function App() {
-  const [text, setText] = React.useState<string | null>(null);
+const queryClient = new QueryClient();
 
-  React.useEffect(() => {
-    setText("Hydrated");
-  });
+export function App(props) {
+  const inBrowser = typeof window !== "undefined";
+
+  const Router = inBrowser ? BrowserRouter : StaticRouter;
 
   return (
-    <>
+    <QueryClientProvider client={queryClient}>
       <head>
         <link rel="stylesheet" href="http://localhost:7700/main.css"></link>
       </head>
       <body>
-        <div>{text || "Hello world"}</div>
-        <Button>Semantic button</Button>
+        <Router context={props.routerContext} location={props.reqUrl}>
+          <Redirect from="/" to="/create-noun" />
+          <Route path="/create-noun" component={CreateNoun} />
+        </Router>
         <script src="http://localhost:7700/flax.js"></script>
       </body>
-    </>
+    </QueryClientProvider>
   );
+}
+
+export interface RouterContext {
+  url?: string;
 }

--- a/frontend/Nouns/CreateNoun.tsx
+++ b/frontend/Nouns/CreateNoun.tsx
@@ -1,0 +1,56 @@
+import { useState } from "react";
+import { Input, Form, Button } from "semantic-ui-react";
+import { RouterProps } from "react-router";
+import { useMutation } from "react-query";
+import { flaxFetch } from "../Utils/flaxFetch";
+import { unary, kebabCase } from "lodash-es";
+
+export function CreateNoun(props: RouterProps) {
+  const [nounName, setNounName] = useState<string>("");
+
+  const submitMutation = useMutation<
+    Noun,
+    Error,
+    React.FormEvent<HTMLFormElement>
+  >((evt) => {
+    evt.preventDefault();
+    return flaxFetch(`/api/nouns`, {
+      method: "POST",
+      body: {
+        friendlyName: nounName,
+        tableName: nounName,
+        slug: kebabCase(nounName),
+        parentId: null,
+      },
+    });
+  });
+
+  return (
+    <Form onSubmit={unary(submitMutation.mutate)}>
+      <Form.Field>
+        <label htmlFor="noun-name">
+          What is the name for this data? (Client, Donor, Lead, Invoice)
+        </label>
+        <Input
+          id="noun-name"
+          value={nounName}
+          onChange={(evt) => setNounName(evt.target.value)}
+          required
+        />
+      </Form.Field>
+      <Button type="submit">Create Noun</Button>
+    </Form>
+  );
+}
+
+export interface Noun {
+  id: number;
+  tableName: string;
+  slug: string;
+  friendlyName: string;
+  parentId?: number;
+  createdAt: DbDateTime;
+  updatedAt: DbDateTime;
+}
+
+export type DbDateTime = string;

--- a/frontend/Utils/flaxFetch.tsx
+++ b/frontend/Utils/flaxFetch.tsx
@@ -1,0 +1,40 @@
+import { isPlainObject } from "lodash-es";
+
+export function flaxFetch<ResponseDataType = object>(
+  url: string,
+  options: FlaxFetchOptions
+): Promise<ResponseDataType> {
+  if (isPlainObject(options?.body) && !(options?.body instanceof FormData)) {
+    options.body = JSON.stringify(options.body);
+    options.headers = options.headers || {};
+    options.headers["content-type"] = "application/json";
+  }
+
+  return fetch(url, options as RequestInit).then((r) => {
+    if (r.ok) {
+      if (r.status === 204) {
+        return;
+      } else if (
+        r.headers["content-type"] &&
+        r.headers["content-type"].includes("application/json")
+      ) {
+        return r.json();
+      } else if (
+        r.headers["content-length"] &&
+        r.headers["content-length"] > 0
+      ) {
+        return r.text();
+      }
+    } else {
+      throw Error(
+        `Server responded with ${r.status} ${r.statusText} when requesting ${
+          options?.method ?? "GET"
+        } ${url}`
+      );
+    }
+  });
+}
+
+export type FlaxFetchOptions = Omit<RequestInit, "body"> & {
+  body: object | BodyInit;
+};

--- a/models/noun.d.ts
+++ b/models/noun.d.ts
@@ -1,0 +1,10 @@
+import Model from "sequelize/lib/model.js";
+
+export abstract class NounModel extends Model<Noun> {}
+
+export interface Noun {
+  tableName: string;
+  slug: string;
+  friendlyName: string;
+  parentId: string;
+}

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "develop": "concurrently \"pnpm:develop:*\"",
-    "develop:backend": "cross-env \"NODE_OPTIONS=--experimental-loader ts-node/esm  --experimental-specifier-resolution=node\" nodemon --signal SIGINT backend/Server.ts --watch backend --watch migrations --ext tsx,ts,js -- --experimental-specifier-resolution=node",
+    "develop:backend": "cross-env \"NODE_OPTIONS=--experimental-loader ts-node/esm  --experimental-specifier-resolution=node\" nodemon --signal SIGINT backend/Server.ts --watch backend --watch migrations --ext tsx,ts,js",
     "develop:db": "docker-compose up",
     "develop:frontend": "webpack serve --config webpack.config.cjs --port 7700",
     "check-format": "prettier --check .",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "develop": "concurrently \"pnpm:develop:*\"",
-    "develop:backend": "cross-env \"NODE_OPTIONS=--experimental-loader ts-node/esm\" nodemon backend/Server.ts --watch backend --watch frontend --watch migrations --ext tsx,ts,js",
+    "develop:backend": "cross-env \"NODE_OPTIONS=--experimental-loader ts-node/esm  --experimental-specifier-resolution=node\" nodemon --signal SIGINT backend/Server.ts --watch backend --watch migrations --ext tsx,ts,js -- --experimental-specifier-resolution=node",
     "develop:db": "docker-compose up",
     "develop:frontend": "webpack serve --config webpack.config.cjs --port 7700",
     "check-format": "prettier --check .",
@@ -49,16 +49,26 @@
     "webpack-dev-server": "^3.11.2"
   },
   "dependencies": {
-    "@types/react": "^17.0.8",
-    "@types/react-dom": "^17.0.5",
+    "@types/express": "^4.17.12",
+    "@types/lodash-es": "^4.17.4",
+    "@types/react": "^17.0.11",
+    "@types/react-dom": "^17.0.8",
+    "@types/react-router": "^5.1.15",
     "body-parser": "^1.19.0",
     "express": "^4.17.1",
     "express-promise-router": "^4.1.0",
+    "express-validator": "^6.12.0",
+    "lodash-es": "^4.17.21",
+    "open": "^8.2.1",
     "pg": "^8.6.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
+    "react-query": "^3.17.2",
+    "react-router": "^5.2.0",
+    "react-router-dom": "^5.2.0",
     "semantic-ui-css": "^2.4.1",
     "semantic-ui-react": "^2.0.3",
-    "sequelize": "^6.6.2"
+    "sequelize": "^6.6.2",
+    "tree-kill": "^1.2.2"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,8 +4,11 @@ specifiers:
   '@babel/core': ^7.14.2
   '@babel/eslint-parser': ^7.14.2
   '@babel/preset-typescript': ^7.13.0
-  '@types/react': ^17.0.8
-  '@types/react-dom': ^17.0.5
+  '@types/express': ^4.17.12
+  '@types/lodash-es': ^4.17.4
+  '@types/react': ^17.0.11
+  '@types/react-dom': ^17.0.8
+  '@types/react-router': ^5.1.15
   body-parser: ^1.19.0
   concurrently: ^6.1.0
   cross-env: ^7.0.3
@@ -14,20 +17,27 @@ specifiers:
   eslint-config-ts-react-important-stuff: ^3.0.0
   express: ^4.17.1
   express-promise-router: ^4.1.0
+  express-validator: ^6.12.0
   file-loader: ^6.2.0
   husky: ^6.0.0
+  lodash-es: ^4.17.21
   mini-css-extract-plugin: ^1.6.0
   nodemon: ^2.0.7
+  open: ^8.2.1
   pg: ^8.6.0
   prettier: ^2.3.0
   pretty-quick: ^3.1.0
   react: ^17.0.2
   react-dom: ^17.0.2
+  react-query: ^3.17.2
+  react-router: ^5.2.0
+  react-router-dom: ^5.2.0
   semantic-ui-css: ^2.4.1
   semantic-ui-react: ^2.0.3
   sequelize: ^6.6.2
   sequelize-cli: ^6.2.0
   style-loader: ^2.0.0
+  tree-kill: ^1.2.2
   ts-loader: ^9.2.2
   ts-node: ^9.1.1
   typescript: ^4.2.4
@@ -37,17 +47,27 @@ specifiers:
   webpack-dev-server: ^3.11.2
 
 dependencies:
-  '@types/react': 17.0.8
-  '@types/react-dom': 17.0.5
+  '@types/express': 4.17.12
+  '@types/lodash-es': 4.17.4
+  '@types/react': 17.0.11
+  '@types/react-dom': 17.0.8
+  '@types/react-router': 5.1.15
   body-parser: 1.19.0
   express: 4.17.1
-  express-promise-router: 4.1.0_express@4.17.1
+  express-promise-router: 4.1.0_1e4d5aefc915886dae9e998bf55b0fd2
+  express-validator: 6.12.0
+  lodash-es: 4.17.21
+  open: 8.2.1
   pg: 8.6.0
   react: 17.0.2
   react-dom: 17.0.2_react@17.0.2
+  react-query: 3.17.2_react-dom@17.0.2+react@17.0.2
+  react-router: 5.2.0_react@17.0.2
+  react-router-dom: 5.2.0_react@17.0.2
   semantic-ui-css: 2.4.1
   semantic-ui-react: 2.0.3_react-dom@17.0.2+react@17.0.2
   sequelize: 6.6.2_pg@8.6.0
+  tree-kill: 1.2.2
 
 devDependencies:
   '@babel/core': 7.14.2
@@ -324,6 +344,13 @@ packages:
     dependencies:
       regenerator-runtime: 0.13.7
 
+  /@babel/runtime/7.14.6:
+    resolution: {integrity: sha512-/PCB2uJ7oM44tz8YhC4Z/6PeOKXp4K588f+5M3clr1M4zbqztlo0XEfJ2LEzj/FgwfgGcIdl8n7YYjTCI0BYwg==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      regenerator-runtime: 0.13.7
+    dev: false
+
   /@babel/template/7.12.13:
     resolution: {integrity: sha512-/7xxiGA57xMo/P2GVvdEumr8ONhFOhfgq2ihK3h1e6THqzTAkHbkXgB0xI9yeTfIUoH3+oAeHhqm/I43OTbbjA==}
     dependencies:
@@ -422,6 +449,19 @@ packages:
       defer-to-connect: 1.1.3
     dev: true
 
+  /@types/body-parser/1.19.0:
+    resolution: {integrity: sha512-W98JrE0j2K78swW4ukqMleo8R7h/pFETjM2DQ90MF6XK2i4LO4W3gQ71Lt4w3bfm2EvVSyWHplECvB5sK22yFQ==}
+    dependencies:
+      '@types/connect': 3.4.34
+      '@types/node': 15.12.4
+    dev: false
+
+  /@types/connect/3.4.34:
+    resolution: {integrity: sha512-ePPA/JuI+X0vb+gSWlPKOY0NdNAie/rPUqX2GUPpbZwiKTkSPhjXWuee47E4MtE54QVzGCQMQkAL6JhV2E1+cQ==}
+    dependencies:
+      '@types/node': 15.12.4
+    dev: false
+
   /@types/eslint-scope/3.7.0:
     resolution: {integrity: sha512-O/ql2+rrCUe2W2rs7wMR+GqPRcgB6UiqN5RhrR5xruFlY7l9YLMn0ZkDzjoHLeiFkR8MCQZVudUuuvQ2BLC9Qw==}
     dependencies:
@@ -440,6 +480,23 @@ packages:
     resolution: {integrity: sha512-c5ciR06jK8u9BstrmJyO97m+klJrrhCf9u3rLu3DEAJBirxRqSCvDQoYKmxuYwQI5SZChAWu+tq9oVlGRuzPAg==}
     dev: true
 
+  /@types/express-serve-static-core/4.17.21:
+    resolution: {integrity: sha512-gwCiEZqW6f7EoR8TTEfalyEhb1zA5jQJnRngr97+3pzMaO1RKoI1w2bw07TK72renMUVWcWS5mLI6rk1NqN0nA==}
+    dependencies:
+      '@types/node': 15.12.4
+      '@types/qs': 6.9.6
+      '@types/range-parser': 1.2.3
+    dev: false
+
+  /@types/express/4.17.12:
+    resolution: {integrity: sha512-pTYas6FrP15B1Oa0bkN5tQMNqOcVXa9j4FTFtO8DWI9kppKib+6NJtfTOOLcwxuuYvcX2+dVG6et1SxW/Kc17Q==}
+    dependencies:
+      '@types/body-parser': 1.19.0
+      '@types/express-serve-static-core': 4.17.21
+      '@types/qs': 6.9.6
+      '@types/serve-static': 1.13.9
+    dev: false
+
   /@types/glob/7.1.3:
     resolution: {integrity: sha512-SEYeGAIQIQX8NN6LDKprLjbrd5dARM5EXsd8GI/A5l0apYI1fGMWgPHSe4ZKL4eozlAyI+doUE9XbYS4xCkQ1w==}
     dependencies:
@@ -447,13 +504,35 @@ packages:
       '@types/node': 15.6.1
     dev: true
 
+  /@types/history/4.7.8:
+    resolution: {integrity: sha512-S78QIYirQcUoo6UJZx9CSP0O2ix9IaeAXwQi26Rhr/+mg7qqPy8TzaxHSUut7eGjL8WmLccT7/MXf304WjqHcA==}
+    dev: false
+
   /@types/json-schema/7.0.7:
     resolution: {integrity: sha512-cxWFQVseBm6O9Gbw1IWb8r6OS4OhSt3hPZLkFApLjM8TEXROBuQGLAH2i2gZpcXdLBIrpXuTDhH7Vbm1iXmNGA==}
     dev: true
 
+  /@types/lodash-es/4.17.4:
+    resolution: {integrity: sha512-BBz79DCJbD2CVYZH67MBeHZRX++HF+5p8Mo5MzjZi64Wac39S3diedJYHZtScbRVf4DjZyN6LzA0SB0zy+HSSQ==}
+    dependencies:
+      '@types/lodash': 4.14.170
+    dev: false
+
+  /@types/lodash/4.14.170:
+    resolution: {integrity: sha512-bpcvu/MKHHeYX+qeEN8GE7DIravODWdACVA1ctevD8CN24RhPZIKMn9ntfAsrvLfSX3cR5RrBKAbYm9bGs0A+Q==}
+    dev: false
+
+  /@types/mime/1.3.2:
+    resolution: {integrity: sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw==}
+    dev: false
+
   /@types/minimatch/3.0.4:
     resolution: {integrity: sha512-1z8k4wzFnNjVK/tlxvrWuK5WMt6mydWWP7+zvH5eFep4oj+UkrfiJTRtjCeBXNpwaA/FYqqtb4/QS4ianFpIRA==}
     dev: true
+
+  /@types/node/15.12.4:
+    resolution: {integrity: sha512-zrNj1+yqYF4WskCMOHwN+w9iuD12+dGm0rQ35HLl9/Ouuq52cEtd0CH9qMgrdNmi5ejC1/V7vKEXYubB+65DkA==}
+    dev: false
 
   /@types/node/15.3.0:
     resolution: {integrity: sha512-8/bnjSZD86ZfpBsDlCIkNXIvm+h6wi9g7IqL+kmFkQ+Wvu3JrasgLElfiPgoo8V8vVfnEi0QVS12gbl94h9YsQ==}
@@ -471,14 +550,29 @@ packages:
     resolution: {integrity: sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw==}
     dev: false
 
-  /@types/react-dom/17.0.5:
-    resolution: {integrity: sha512-ikqukEhH4H9gr4iJCmQVNzTB307kROe3XFfHAOTxOXPOw7lAoEXnM5KWTkzeANGL5Ce6ABfiMl/zJBYNi7ObmQ==}
-    dependencies:
-      '@types/react': 17.0.8
+  /@types/qs/6.9.6:
+    resolution: {integrity: sha512-0/HnwIfW4ki2D8L8c9GVcG5I72s9jP5GSLVF0VIXDW00kmIpA6O33G7a8n59Tmh7Nz0WUC3rSb7PTY/sdW2JzA==}
     dev: false
 
-  /@types/react/17.0.8:
-    resolution: {integrity: sha512-3sx4c0PbXujrYAKwXxNONXUtRp9C+hE2di0IuxFyf5BELD+B+AXL8G7QrmSKhVwKZDbv0igiAjQAMhXj8Yg3aw==}
+  /@types/range-parser/1.2.3:
+    resolution: {integrity: sha512-ewFXqrQHlFsgc09MK5jP5iR7vumV/BYayNC6PgJO2LPe8vrnNFyjQjSppfEngITi0qvfKtzFvgKymGheFM9UOA==}
+    dev: false
+
+  /@types/react-dom/17.0.8:
+    resolution: {integrity: sha512-0ohAiJAx1DAUEcY9UopnfwCE9sSMDGnY/oXjWMax6g3RpzmTt2GMyMVAXcbn0mo8XAff0SbQJl2/SBU+hjSZ1A==}
+    dependencies:
+      '@types/react': 17.0.11
+    dev: false
+
+  /@types/react-router/5.1.15:
+    resolution: {integrity: sha512-z3UlMG/x91SFEVmmvykk9FLTliDvfdIUky4k2rCfXWQ0NKbrP8o9BTCaCTPuYsB8gDkUnUmkcA2vYlm2DR+HAA==}
+    dependencies:
+      '@types/history': 4.7.8
+      '@types/react': 17.0.11
+    dev: false
+
+  /@types/react/17.0.11:
+    resolution: {integrity: sha512-yFRQbD+whVonItSk7ZzP/L+gPTJVBkL/7shLEF+i9GC/1cV3JmUxEQz6+9ylhUpWSDuqo1N9qEvqS6vTj4USUA==}
     dependencies:
       '@types/prop-types': 15.7.3
       '@types/scheduler': 0.16.1
@@ -487,6 +581,13 @@ packages:
 
   /@types/scheduler/0.16.1:
     resolution: {integrity: sha512-EaCxbanVeyxDRTQBkdLb3Bvl/HK7PBK6UJjsSixB0iHKoWxE5uu2Q/DgtpOhPIojN0Zl1whvOd7PoHs2P0s5eA==}
+    dev: false
+
+  /@types/serve-static/1.13.9:
+    resolution: {integrity: sha512-ZFqF6qa48XsPdjXV5Gsz0Zqmux2PerNd3a/ktL45mHpa19cuMi/cL8tcxdAx497yRh+QtYPuofjT9oWw9P7nkA==}
+    dependencies:
+      '@types/mime': 1.3.2
+      '@types/node': 15.12.4
     dev: false
 
   /@webassemblyjs/ast/1.11.0:
@@ -866,7 +967,6 @@ packages:
 
   /balanced-match/1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
-    dev: true
 
   /base/0.11.2:
     resolution: {integrity: sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==}
@@ -884,6 +984,11 @@ packages:
   /batch/0.6.1:
     resolution: {integrity: sha1-3DQxT05nkxgJP8dgJyUl+UvyXBY=}
     dev: true
+
+  /big-integer/1.6.48:
+    resolution: {integrity: sha512-j51egjPa7/i+RdiRuJbPdJ2FIUYYPhvYLjzoYbcMMm62ooO6F94fETG4MTs46zPAF9Brs04OajboA/qTGuz78w==}
+    engines: {node: '>=0.6'}
+    dev: false
 
   /big.js/5.2.2:
     resolution: {integrity: sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==}
@@ -955,7 +1060,6 @@ packages:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
-    dev: true
 
   /braces/2.3.2:
     resolution: {integrity: sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==}
@@ -979,6 +1083,19 @@ packages:
     dependencies:
       fill-range: 7.0.1
     dev: true
+
+  /broadcast-channel/3.7.0:
+    resolution: {integrity: sha512-cIAKJXAxGJceNZGTZSBzMxzyOn72cVgPnKx4dc6LRjQgbaJUQqhy5rzL3zbMxkMWsGKkv2hSFkPRMEXfoMZ2Mg==}
+    dependencies:
+      '@babel/runtime': 7.14.6
+      detect-node: 2.1.0
+      js-sha3: 0.8.0
+      microseconds: 0.2.0
+      nano-time: 1.0.0
+      oblivious-set: 1.0.0
+      rimraf: 3.0.2
+      unload: 2.2.0
+    dev: false
 
   /browserslist/4.16.6:
     resolution: {integrity: sha512-Wspk/PqO+4W9qp5iUTJsa1B/QrYn1keNCcEP5OvP7WBwT4KaDly0uONYmC6Xa3Z5IqnUgS0KcgLYu1l74x0ZXQ==}
@@ -1247,7 +1364,6 @@ packages:
 
   /concat-map/0.0.1:
     resolution: {integrity: sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=}
-    dev: true
 
   /concurrently/6.1.0:
     resolution: {integrity: sha512-jy+xj49pvqeKjc2TAVXRIhrgPG51eBKDZti0kZ41kaWk9iLbyWBjH6KMFpW7peOLkEymD+ZM83Lx6UEy3N/M9g==}
@@ -1492,6 +1608,11 @@ packages:
     resolution: {integrity: sha512-0ISdNousHvZT2EiFlZeZAHBUvSxmKswVCEf8hW7KWgG4a8MVEu/3Vb6uWYozkjylyCxe0JBIiRB1jV45S70WVQ==}
     dev: true
 
+  /define-lazy-prop/2.0.0:
+    resolution: {integrity: sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==}
+    engines: {node: '>=8'}
+    dev: false
+
   /define-properties/1.1.3:
     resolution: {integrity: sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==}
     engines: {node: '>= 0.4'}
@@ -1543,7 +1664,6 @@ packages:
 
   /detect-node/2.1.0:
     resolution: {integrity: sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==}
-    dev: true
 
   /diff/4.0.2:
     resolution: {integrity: sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==}
@@ -1984,7 +2104,7 @@ packages:
       to-regex: 3.0.2
     dev: true
 
-  /express-promise-router/4.1.0_express@4.17.1:
+  /express-promise-router/4.1.0_1e4d5aefc915886dae9e998bf55b0fd2:
     resolution: {integrity: sha512-nvg0X1Rj8oajPPC+fG3t4e740aNmQZRZY6dRLbiiM56Dvd8213RJ4kaxhZVTdQLut+l4DZdfeJkyx2VENPMBdw==}
     engines: {node: '>=10'}
     peerDependencies:
@@ -1994,10 +2114,19 @@ packages:
       '@types/express':
         optional: true
     dependencies:
+      '@types/express': 4.17.12
       express: 4.17.1
       is-promise: 4.0.0
       lodash.flattendeep: 4.4.0
       methods: 1.1.2
+    dev: false
+
+  /express-validator/6.12.0:
+    resolution: {integrity: sha512-lcQAdVeAO+pBbHD33nIsDsd+QPakLX08tJ82iEsXj6ezyWCfYjE9RY/g9SVq5z4G0NaIkH8039Oe4r0G92DRyA==}
+    engines: {node: '>= 8.0.0'}
+    dependencies:
+      lodash: 4.17.21
+      validator: 13.6.0
     dev: false
 
   /express/4.17.1:
@@ -2211,7 +2340,6 @@ packages:
 
   /fs.realpath/1.0.0:
     resolution: {integrity: sha1-FQStJSMVjKpA20onh8sBQRmU6k8=}
-    dev: true
 
   /fsevents/1.2.13:
     resolution: {integrity: sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==}
@@ -2304,7 +2432,6 @@ packages:
       minimatch: 3.0.4
       once: 1.4.0
       path-is-absolute: 1.0.1
-    dev: true
 
   /global-dirs/2.1.0:
     resolution: {integrity: sha512-MG6kdOUh/xBnyo9cJFeIKkLEc1AyFq42QTU4XiX51i2NEdxLxLWXIjEjmqKeSuKR7pAZjTqUVoT2b2huxVLgYQ==}
@@ -2429,6 +2556,23 @@ packages:
     dependencies:
       function-bind: 1.1.1
     dev: true
+
+  /history/4.10.1:
+    resolution: {integrity: sha512-36nwAD620w12kuzPAsyINPWJqlNbij+hpK1k9XRloDtym8mxzGYl2c17LnV6IAGB2Dmg4tEa7G7DlawS0+qjew==}
+    dependencies:
+      '@babel/runtime': 7.14.6
+      loose-envify: 1.4.0
+      resolve-pathname: 3.0.0
+      tiny-invariant: 1.1.0
+      tiny-warning: 1.0.3
+      value-equal: 1.0.1
+    dev: false
+
+  /hoist-non-react-statics/3.3.2:
+    resolution: {integrity: sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==}
+    dependencies:
+      react-is: 16.13.1
+    dev: false
 
   /hosted-git-info/2.8.9:
     resolution: {integrity: sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==}
@@ -2588,7 +2732,6 @@ packages:
     dependencies:
       once: 1.4.0
       wrappy: 1.0.2
-    dev: true
 
   /inherits/2.0.3:
     resolution: {integrity: sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=}
@@ -2738,6 +2881,12 @@ packages:
       is-data-descriptor: 1.0.0
       kind-of: 6.0.3
     dev: true
+
+  /is-docker/2.2.1:
+    resolution: {integrity: sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==}
+    engines: {node: '>=8'}
+    hasBin: true
+    dev: false
 
   /is-extendable/0.1.1:
     resolution: {integrity: sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=}
@@ -2903,9 +3052,20 @@ packages:
     engines: {node: '>=4'}
     dev: true
 
+  /is-wsl/2.2.0:
+    resolution: {integrity: sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==}
+    engines: {node: '>=8'}
+    dependencies:
+      is-docker: 2.2.1
+    dev: false
+
   /is-yarn-global/0.3.0:
     resolution: {integrity: sha512-VjSeb/lHmkoyd8ryPVIKvOCn4D1koMqY+vqyjjUfc3xyKtP4dYOxM44sZrnqQSzSds3xyOrUTLTC9LVCVgLngw==}
     dev: true
+
+  /isarray/0.0.1:
+    resolution: {integrity: sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=}
+    dev: false
 
   /isarray/1.0.0:
     resolution: {integrity: sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=}
@@ -2951,6 +3111,10 @@ packages:
       mkdirp: 1.0.4
       nopt: 5.0.0
     dev: true
+
+  /js-sha3/0.8.0:
+    resolution: {integrity: sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q==}
+    dev: false
 
   /js-tokens/4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
@@ -3198,6 +3362,13 @@ packages:
       object-visit: 1.0.1
     dev: true
 
+  /match-sorter/6.3.0:
+    resolution: {integrity: sha512-efYOf/wUpNb8FgNY+cOD2EIJI1S5I7YPKsw0LBp7wqPh5pmMS6i/wr3ZWwfwrAw1NvqTA2KUReVRWDX84lUcOQ==}
+    dependencies:
+      '@babel/runtime': 7.14.6
+      remove-accents: 0.4.2
+    dev: false
+
   /media-typer/0.3.0:
     resolution: {integrity: sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=}
     engines: {node: '>= 0.6'}
@@ -3260,6 +3431,10 @@ packages:
       picomatch: 2.3.0
     dev: true
 
+  /microseconds/0.2.0:
+    resolution: {integrity: sha512-n7DHHMjR1avBbSpsTBj6fmMGh2AGrifVV4e+WYc3Q9lO+xnSZ3NyhcBND3vzzatt05LFhoKFRxrIyklmLlUtyA==}
+    dev: false
+
   /mime-db/1.47.0:
     resolution: {integrity: sha512-QBmA/G2y+IfeS4oktet3qRZ+P5kPhCKRXxXnQEudYqUaEioAU1/Lq2us3D/t1Jfo4hE9REQPrbB7K5sOczJVIw==}
     engines: {node: '>= 0.6'}
@@ -3291,6 +3466,18 @@ packages:
     engines: {node: '>=4'}
     dev: true
 
+  /mini-create-react-context/0.4.1_prop-types@15.7.2+react@17.0.2:
+    resolution: {integrity: sha512-YWCYEmd5CQeHGSAKrYvXgmzzkrvssZcuuQDDeqkT+PziKGMgE+0MCCtcKbROzocGBG1meBLl2FotlRwf4gAzbQ==}
+    peerDependencies:
+      prop-types: ^15.0.0
+      react: ^0.14.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+    dependencies:
+      '@babel/runtime': 7.14.6
+      prop-types: 15.7.2
+      react: 17.0.2
+      tiny-warning: 1.0.3
+    dev: false
+
   /mini-css-extract-plugin/1.6.0_webpack@5.37.1:
     resolution: {integrity: sha512-nPFKI7NSy6uONUo9yn2hIfb9vyYvkFu95qki0e21DQ9uaqNKDP15DGpK0KnV6wDroWxPHtExrdEwx/yDQ8nVRw==}
     engines: {node: '>= 10.13.0'}
@@ -3311,7 +3498,6 @@ packages:
     resolution: {integrity: sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==}
     dependencies:
       brace-expansion: 1.1.11
-    dev: true
 
   /minimist/1.2.5:
     resolution: {integrity: sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==}
@@ -3393,6 +3579,12 @@ packages:
     resolution: {integrity: sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==}
     dev: true
     optional: true
+
+  /nano-time/1.0.0:
+    resolution: {integrity: sha1-sFVPaa2J4i0JB/ehKwmTpdlhN+8=}
+    dependencies:
+      big-integer: 1.6.48
+    dev: false
 
   /nanoid/3.1.23:
     resolution: {integrity: sha512-FiB0kzdP0FFVGDKlRLEQ1BgDzU87dy5NnzjeW9YZNt+/c3+q82EQDUwniSAUxp/F0gFNI1ZhKU1FqYsMuqZVnw==}
@@ -3577,6 +3769,10 @@ packages:
       isobject: 3.0.1
     dev: true
 
+  /oblivious-set/1.0.0:
+    resolution: {integrity: sha512-z+pI07qxo4c2CulUHCDf9lcqDlMSo72N/4rLUpRXf6fu+q8vjt8y0xS+Tlf8NTJDdTXHbdeO1n3MlbctwEoXZw==}
+    dev: false
+
   /obuf/1.1.2:
     resolution: {integrity: sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg==}
     dev: true
@@ -3596,7 +3792,6 @@ packages:
     resolution: {integrity: sha1-WDsap3WWHUsROsF9nFC6753Xa9E=}
     dependencies:
       wrappy: 1.0.2
-    dev: true
 
   /onetime/5.1.2:
     resolution: {integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==}
@@ -3604,6 +3799,15 @@ packages:
     dependencies:
       mimic-fn: 2.1.0
     dev: true
+
+  /open/8.2.1:
+    resolution: {integrity: sha512-rXILpcQlkF/QuFez2BJDf3GsqpjGKbkUUToAIGo9A0Q6ZkoSGogZJulrUdwRkrAsoQvoZsrjCYt8+zblOk7JQQ==}
+    engines: {node: '>=12'}
+    dependencies:
+      define-lazy-prop: 2.0.0
+      is-docker: 2.2.1
+      is-wsl: 2.2.0
+    dev: false
 
   /opn/5.5.0:
     resolution: {integrity: sha512-PqHpggC9bLV0VeWcdKhkpxY+3JTzetLSqTCWL/z/tFIbI6G8JCjondXklT1JinczLz2Xib62sSp0T/gKT4KksA==}
@@ -3742,7 +3946,6 @@ packages:
   /path-is-absolute/1.0.1:
     resolution: {integrity: sha1-F0uSaHNVNP+8es5r9TpanhtcX18=}
     engines: {node: '>=0.10.0'}
-    dev: true
 
   /path-is-inside/1.0.2:
     resolution: {integrity: sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=}
@@ -3764,6 +3967,12 @@ packages:
 
   /path-to-regexp/0.1.7:
     resolution: {integrity: sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=}
+
+  /path-to-regexp/1.8.0:
+    resolution: {integrity: sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==}
+    dependencies:
+      isarray: 0.0.1
+    dev: false
 
   /pg-connection-string/2.5.0:
     resolution: {integrity: sha512-r5o/V/ORTA6TmUnyWZR9nCj1klXCO2CEKNRlVuJptZe85QuhFayC7WeMic7ndayT5IRIR0S0xFxFi2ousartlQ==}
@@ -4130,6 +4339,58 @@ packages:
       warning: 4.0.3
     dev: false
 
+  /react-query/3.17.2_react-dom@17.0.2+react@17.0.2:
+    resolution: {integrity: sha512-icMtYL/+jUv0Q3n8GRz6CTyMYKh+l5EBKwhkr8qhbtYRORr43YGiN6EJSyw9WFaSQ9bwD1G9ZhaFxow9NMV0Sw==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0
+      react-dom: '*'
+      react-native: '*'
+    peerDependenciesMeta:
+      react-dom:
+        optional: true
+      react-native:
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.14.6
+      broadcast-channel: 3.7.0
+      match-sorter: 6.3.0
+      react: 17.0.2
+      react-dom: 17.0.2_react@17.0.2
+    dev: false
+
+  /react-router-dom/5.2.0_react@17.0.2:
+    resolution: {integrity: sha512-gxAmfylo2QUjcwxI63RhQ5G85Qqt4voZpUXSEqCwykV0baaOTQDR1f0PmY8AELqIyVc0NEZUj0Gov5lNGcXgsA==}
+    peerDependencies:
+      react: '>=15'
+    dependencies:
+      '@babel/runtime': 7.14.6
+      history: 4.10.1
+      loose-envify: 1.4.0
+      prop-types: 15.7.2
+      react: 17.0.2
+      react-router: 5.2.0_react@17.0.2
+      tiny-invariant: 1.1.0
+      tiny-warning: 1.0.3
+    dev: false
+
+  /react-router/5.2.0_react@17.0.2:
+    resolution: {integrity: sha512-smz1DUuFHRKdcJC0jobGo8cVbhO3x50tCL4icacOlcwDOEQPq4TMqwx3sY1TP+DvtTgz4nm3thuo7A+BK2U0Dw==}
+    peerDependencies:
+      react: '>=15'
+    dependencies:
+      '@babel/runtime': 7.14.6
+      history: 4.10.1
+      hoist-non-react-statics: 3.3.2
+      loose-envify: 1.4.0
+      mini-create-react-context: 0.4.1_prop-types@15.7.2+react@17.0.2
+      path-to-regexp: 1.8.0
+      prop-types: 15.7.2
+      react: 17.0.2
+      react-is: 16.13.1
+      tiny-invariant: 1.1.0
+      tiny-warning: 1.0.3
+    dev: false
+
   /react/17.0.2:
     resolution: {integrity: sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==}
     engines: {node: '>=0.10.0'}
@@ -4222,6 +4483,10 @@ packages:
       rc: 1.2.8
     dev: true
 
+  /remove-accents/0.4.2:
+    resolution: {integrity: sha1-CkPTqq4egNuRngeuJUsoXZ4ce7U=}
+    dev: false
+
   /remove-trailing-separator/1.1.0:
     resolution: {integrity: sha1-wkvOKig62tW8P1jg1IJJuSN52O8=}
     dev: true
@@ -4271,6 +4536,10 @@ packages:
     engines: {node: '>=4'}
     dev: true
 
+  /resolve-pathname/3.0.0:
+    resolution: {integrity: sha512-C7rARubxI8bXFNB/hqcp/4iUeIXJhJZvFPFPiSPRnhU5UPxzMFIl+2E6yY6c4k9giDJAhtV+enfA+G89N6Csng==}
+    dev: false
+
   /resolve-url/0.2.1:
     resolution: {integrity: sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=}
     deprecated: https://github.com/lydell/resolve-url#deprecated
@@ -4317,7 +4586,6 @@ packages:
     hasBin: true
     dependencies:
       glob: 7.1.7
-    dev: true
 
   /rxjs/6.6.7:
     resolution: {integrity: sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==}
@@ -4962,6 +5230,14 @@ packages:
       next-tick: 1.1.0
     dev: true
 
+  /tiny-invariant/1.1.0:
+    resolution: {integrity: sha512-ytxQvrb1cPc9WBEI/HSeYYoGD0kWnGEOR8RY6KomWLBVhqz0RgTwVO9dLrGz7dC+nN9llyI7OKAgRq8Vq4ZBSw==}
+    dev: false
+
+  /tiny-warning/1.0.3:
+    resolution: {integrity: sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==}
+    dev: false
+
   /to-fast-properties/2.0.0:
     resolution: {integrity: sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=}
     engines: {node: '>=4'}
@@ -5022,7 +5298,6 @@ packages:
   /tree-kill/1.2.2:
     resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
     hasBin: true
-    dev: true
 
   /ts-loader/9.2.2_typescript@4.2.4+webpack@5.37.1:
     resolution: {integrity: sha512-hNIhGTQHtNKjOzR2ZtQ2OSVbXPykOae+zostf1IlHCf61Mt41GMJurKNqrYUbzHgpmj6UWRu8eBfb7q0XliV0g==}
@@ -5152,6 +5427,13 @@ packages:
     engines: {node: '>= 4.0.0'}
     dev: true
 
+  /unload/2.2.0:
+    resolution: {integrity: sha512-B60uB5TNBLtN6/LsgAf3udH9saB5p7gqJwcFfbOEZ8BcBHnGwCf6G/TGiEqkRAxX7zAFIUtzdrXQSdL3Q/wqNA==}
+    dependencies:
+      '@babel/runtime': 7.14.6
+      detect-node: 2.1.0
+    dev: false
+
   /unpipe/1.0.0:
     resolution: {integrity: sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=}
     engines: {node: '>= 0.8'}
@@ -5273,6 +5555,15 @@ packages:
   /validator/10.11.0:
     resolution: {integrity: sha512-X/p3UZerAIsbBfN/IwahhYaBbY68EN/UQBWHtsbXGT5bfrH/p4NQzUCG1kF/rtKaNpnJ7jAu6NGTdSNtyNIXMw==}
     engines: {node: '>= 0.10'}
+    dev: false
+
+  /validator/13.6.0:
+    resolution: {integrity: sha512-gVgKbdbHgtxpRyR8K0O6oFZPhhB5tT1jeEHZR0Znr9Svg03U0+r9DXWMrnRAB+HtCStDQKlaIZm42tVsVjqtjg==}
+    engines: {node: '>= 0.10'}
+    dev: false
+
+  /value-equal/1.0.1:
+    resolution: {integrity: sha512-NOJ6JZCAWr0zlxZt+xqCHNTEKOsrks2HQd4MqhP1qy4z1SkbEP467eNx6TgDKXMvUOb+OENfJCZwM+16n7fRfw==}
     dev: false
 
   /vary/1.1.2:
@@ -5499,7 +5790,6 @@ packages:
 
   /wrappy/1.0.2:
     resolution: {integrity: sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=}
-    dev: true
 
   /write-file-atomic/3.0.3:
     resolution: {integrity: sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,7 @@
     "moduleResolution": "node",
     "resolveJsonModule": true,
     "strictNullChecks": true,
-    "jsx": "react",
+    "jsx": "react-jsx",
     "sourceMap": true,
     "lib": [
       "dom",


### PR DESCRIPTION
Not the most impressive visually, but here's the screenshot

![image](https://user-images.githubusercontent.com/5524384/123008667-8bcdf900-d378-11eb-90bb-d8dd3081b456.png)

Here's what I added:

- react-query for submitting forms and queries
- express-validator for verifying api requests
- typescript autocompletion for sequelize queries
- fix issues with nodemon / concurrently not correctly killing old processes (port already in use error)
- Add react-router, including server-side redirects
- implement flaxFetch, which is a small wrapper around fetch that makes it easier to use
- no longer require `import * as React from 'react'` in all files
- disallow creating two nouns with the same tableName