### PR TITLE
Batch create fields endpoint

### DIFF
--- a/backend/Fields/BatchPostFields.ts
+++ b/backend/Fields/BatchPostFields.ts
@@ -1,0 +1,55 @@
+import { FieldAttributes, FieldModel } from "../../models/field.js";
+import { NounAttributes, NounModel } from "../../models/noun.js";
+import { sequelize } from "../DB.js";
+import { router } from "../Router.js";
+import { invalidRequest, notFound } from "../Utils/EndpointResponses.js";
+import { body, validationResult, param } from "express-validator";
+
+router.post<Params, ResponseBody, RequestBody>(
+  "/api/nouns/:nounId/fields",
+  body("fields").isArray(),
+  body("fields.*.type").isString().trim().toLowerCase(),
+  body("fields.*.columnName").isString().trim(),
+  body("fields.*.friendlyName").isString().trim(),
+  body("fields.*.activeStatus").isBoolean(),
+  param("nounId").isInt().toInt(),
+
+  async (req, res) => {
+    const validationErrors = validationResult(req);
+
+    if (!validationErrors.isEmpty()) {
+      return invalidRequest(res, validationErrors);
+    }
+
+    const { nounId } = req.params;
+
+    let noun: NounAttributes;
+    try {
+      noun = await sequelize.models.Noun.findByPk<NounModel>(req.params.nounId);
+    } catch (err) {
+      notFound(res, `No such noun with id '${req.params.nounId}'`);
+      return;
+    }
+
+    const fieldsToCreate: FieldAttributes[] = req.body.fields.map((field) => {
+      return {
+        ...field,
+        nounId,
+      };
+    });
+
+    const fields: FieldAttributes[] =
+      await sequelize.models.Field.bulkCreate<FieldModel>(fieldsToCreate);
+
+    res.json(fields);
+  }
+);
+
+type FieldToCreate = Omit<FieldAttributes, "nounId">;
+interface Params {
+  nounId: number;
+}
+interface RequestBody {
+  fields: Array<FieldToCreate>;
+}
+type ResponseBody = Array<FieldAttributes>;

--- a/backend/Fields/BatchPostFields.ts
+++ b/backend/Fields/BatchPostFields.ts
@@ -27,6 +27,7 @@ router.post<Params, ResponseBody, RequestBody>(
     try {
       noun = await sequelize.models.Noun.findByPk<NounModel>(req.params.nounId);
     } catch (err) {
+      console.error(err);
       notFound(res, `No such noun with id '${req.params.nounId}'`);
       return;
     }

--- a/backend/RouteImports.ts
+++ b/backend/RouteImports.ts
@@ -3,5 +3,7 @@ import "./Nouns/PostNouns.js";
 import "./Nouns/PatchNouns.js";
 import "./Nouns/DeleteNouns.js";
 
+import "./Fields/BatchPostFields.js";
+
 // WebApp should be at the bottom
 import "./WebApp/WebApp.js";

--- a/backend/Utils/EndpointResponses.ts
+++ b/backend/Utils/EndpointResponses.ts
@@ -1,0 +1,25 @@
+import { Response } from "express";
+import { Result, ValidationError } from "express-validator";
+
+export function notFound(res: Response, msg: EndpointErrorMessage) {
+  res.status(404).json({
+    errors: Array.isArray(msg) ? msg : [msg],
+  });
+}
+
+export function invalidRequest(res: Response, errors: EndpointErrorMessage) {
+  let msg;
+
+  if (Array.isArray((errors as Result<ValidationError>).array)) {
+    res.status;
+    msg = (errors as Result<ValidationError>).array();
+  } else {
+    msg = errors;
+  }
+
+  res.status(400).json({
+    errors: Array.isArray(msg) ? msg : [msg],
+  });
+}
+
+type EndpointErrorMessage = string | Array<string> | Result<ValidationError>;

--- a/backend/nouns/PostNouns.ts
+++ b/backend/nouns/PostNouns.ts
@@ -3,6 +3,7 @@ import { ModelCtor } from "sequelize/lib/model.js";
 import { NounModel } from "../../models/noun.js";
 import { sequelize } from "../DB.js";
 import { router } from "../Router.js";
+import { invalidRequest } from "../Utils/EndpointResponses.js";
 
 router.post(
   "/api/nouns",
@@ -14,9 +15,7 @@ router.post(
     const validationErrors = validationResult(req);
 
     if (!validationErrors.isEmpty()) {
-      return res.status(400).json({
-        errors: validationErrors.array(),
-      });
+      return invalidRequest(res, validationErrors);
     }
 
     const { tableName, slug, friendlyName, parentId } = req.body;

--- a/frontend/Utils/Global.tsx
+++ b/frontend/Utils/Global.tsx
@@ -1,0 +1,1 @@
+export const theGlobal = typeof global === "undefined" ? window : global;

--- a/frontend/Utils/flaxFetch.tsx
+++ b/frontend/Utils/flaxFetch.tsx
@@ -1,4 +1,5 @@
 import { isPlainObject } from "lodash-es";
+import { theGlobal } from "./Global";
 
 export function flaxFetch<ResponseDataType = object>(
   url: string,
@@ -38,3 +39,17 @@ export function flaxFetch<ResponseDataType = object>(
 export type FlaxFetchOptions = Omit<RequestInit, "body"> & {
   body: object | BodyInit;
 };
+
+declare global {
+  interface Window {
+    debugFetch: typeof flaxFetch;
+  }
+
+  namespace NodeJS {
+    interface Global {
+      debugFetch: typeof flaxFetch;
+    }
+  }
+}
+
+theGlobal.debugFetch = flaxFetch;

--- a/models/field.d.ts
+++ b/models/field.d.ts
@@ -1,0 +1,13 @@
+import { Model, Instance } from "sequelize/lib/model.js";
+
+type FieldInstance = Instance<FieldAttributes> & FieldAttributes;
+
+export type FieldModel = Model<FieldInstance, FieldAttributes>;
+
+export interface FieldAttributes {
+  nounId: number;
+  type: string;
+  columnName: string;
+  friendlyName: string;
+  activeStatus: boolean;
+}

--- a/models/noun.d.ts
+++ b/models/noun.d.ts
@@ -1,8 +1,10 @@
-import Model from "sequelize/lib/model.js";
+import { Model, Instance } from "sequelize/lib/model.js";
 
-export abstract class NounModel extends Model<Noun> {}
+type NounInstance = Instance<NounAttributes> & NounAttributes;
 
-export interface Noun {
+export type NounModel = Model<NounInstance, NounAttributes>;
+
+export interface NounAttributes {
   tableName: string;
   slug: string;
   friendlyName: string;

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "develop": "concurrently \"pnpm:develop:*\"",
-    "develop:backend": "cross-env \"NODE_OPTIONS=--experimental-loader ts-node/esm  --experimental-specifier-resolution=node\" nodemon --signal SIGINT backend/Server.ts --watch backend --watch migrations --ext tsx,ts,js",
+    "develop:backend": "cross-env \"NODE_OPTIONS=--experimental-loader ts-node/esm  --experimental-specifier-resolution=node\" nodemon --signal SIGINT backend/Server.ts --watch backend --watch frontend --watch migrations --ext tsx,ts,js",
     "develop:db": "docker-compose up",
     "develop:frontend": "webpack serve --config webpack.config.cjs --port 7700",
     "check-format": "prettier --check .",


### PR DESCRIPTION
This implements the endpoint for creating one or more fields for a noun. I think that a batch endpoint makes more sense than requiring multiple requests when creating the fields for a noun.