### PR TITLE
Add validation to all endpoints

### DIFF
--- a/backend/Utils/EndpointResponses.ts
+++ b/backend/Utils/EndpointResponses.ts
@@ -1,0 +1,25 @@
+import { Response } from "express";
+import { Result, ValidationError } from "express-validator";
+
+export function notFound(res: Response, msg: EndpointErrorMessage) {
+  res.status(404).json({
+    errors: Array.isArray(msg) ? msg : [msg],
+  });
+}
+
+export function invalidRequest(res: Response, errors: EndpointErrorMessage) {
+  let msg;
+
+  if (Array.isArray((errors as Result<ValidationError>).array)) {
+    res.status;
+    msg = (errors as Result<ValidationError>).array();
+  } else {
+    msg = errors;
+  }
+
+  res.status(400).json({
+    errors: Array.isArray(msg) ? msg : [msg],
+  });
+}
+
+type EndpointErrorMessage = string | Array<string> | Result<ValidationError>;

--- a/backend/Utils/EndpointResponses.ts
+++ b/backend/Utils/EndpointResponses.ts
@@ -22,4 +22,8 @@ export function invalidRequest(res: Response, errors: EndpointErrorMessage) {
   });
 }
 
+export function successNoContent(res: Response) {
+  res.status(204).end();
+}
+
 type EndpointErrorMessage = string | Array<string> | Result<ValidationError>;

--- a/backend/nouns/DeleteNouns.ts
+++ b/backend/nouns/DeleteNouns.ts
@@ -22,7 +22,10 @@ router.delete<Params>(
       },
     });
     if (numDeleted === 0) {
-      notFound(res, `No such noun with id '${req.params.nounId}'`);
+      notFound(
+        res,
+        `Could not delete noun - no such noun with id '${req.params.nounId}'`
+      );
     } else {
       successNoContent(res);
     }

--- a/backend/nouns/DeleteNouns.ts
+++ b/backend/nouns/DeleteNouns.ts
@@ -1,7 +1,11 @@
 import { sequelize } from "../DB.js";
 import { router } from "../Router.js";
 import { param, validationResult } from "express-validator";
-import { invalidRequest } from "../Utils/EndpointResponses.js";
+import {
+  invalidRequest,
+  notFound,
+  successNoContent,
+} from "../Utils/EndpointResponses.js";
 
 router.delete<Params>(
   "/api/nouns/:nounId",
@@ -18,9 +22,9 @@ router.delete<Params>(
       },
     });
     if (numDeleted === 0) {
-      res.sendStatus(404);
+      notFound(res, `No such noun with id '${req.params.nounId}'`);
     } else {
-      res.sendStatus(200);
+      successNoContent(res);
     }
   }
 );

--- a/backend/nouns/DeleteNouns.ts
+++ b/backend/nouns/DeleteNouns.ts
@@ -1,15 +1,30 @@
 import { sequelize } from "../DB.js";
 import { router } from "../Router.js";
+import { param, validationResult } from "express-validator";
+import { invalidRequest } from "../Utils/EndpointResponses.js";
 
-router.delete("/api/nouns/:nounId", async (req, res) => {
-  const numDeleted = await sequelize.models.Noun.destroy({
-    where: {
-      id: req.params.nounId,
-    },
-  });
-  if (numDeleted === 0) {
-    res.sendStatus(404);
-  } else {
-    res.sendStatus(200);
+router.delete<Params>(
+  "/api/nouns/:nounId",
+  param("nounId").isInt().toInt(),
+  async (req, res) => {
+    const validationErrors = validationResult(req);
+    if (!validationErrors.isEmpty()) {
+      return invalidRequest(res, validationErrors);
+    }
+
+    const numDeleted = await sequelize.models.Noun.destroy({
+      where: {
+        id: req.params.nounId,
+      },
+    });
+    if (numDeleted === 0) {
+      res.sendStatus(404);
+    } else {
+      res.sendStatus(200);
+    }
   }
-});
+);
+
+interface Params {
+  nounId: number;
+}

--- a/backend/nouns/GetNouns.ts
+++ b/backend/nouns/GetNouns.ts
@@ -1,5 +1,7 @@
 import { sequelize } from "../DB.js";
 import { router } from "../Router.js";
+import { param, validationResult } from "express-validator";
+import { invalidRequest, notFound } from "../Utils/EndpointResponses.js";
 
 router.get("/api/nouns", async (req, res) => {
   const nouns = await sequelize.models.Noun.findAll();
@@ -8,11 +10,25 @@ router.get("/api/nouns", async (req, res) => {
   });
 });
 
-router.get("/api/nouns/:nounId", async (req, res) => {
-  const noun = await sequelize.models.Noun.findByPk(req.params.nounId);
-  if (noun === null) {
-    res.sendStatus(404);
-  } else {
-    res.send(noun);
+router.get<Params>(
+  "/api/nouns/:nounId",
+  param("nounId").isInt().toInt(),
+  async (req, res) => {
+    const validationErrors = validationResult(req);
+    if (!validationErrors.isEmpty()) {
+      return invalidRequest(res, validationErrors);
+    }
+
+    const { nounId } = req.params;
+    const noun = await sequelize.models.Noun.findByPk(nounId);
+    if (noun === null) {
+      notFound(res, `No such noun with id '${nounId}'`);
+    } else {
+      res.send(noun);
+    }
   }
-});
+);
+
+interface Params {
+  nounId: number;
+}

--- a/backend/nouns/PatchNouns.ts
+++ b/backend/nouns/PatchNouns.ts
@@ -1,23 +1,38 @@
 import { sequelize } from "../DB.js";
 import { router } from "../Router.js";
+import { param, validationResult } from "express-validator";
+import { invalidRequest } from "../Utils/EndpointResponses.js";
 
-router.patch("/api/nouns/:nounId", async (req, res) => {
-  const { slug, friendlyName, parentId } = req.body;
-  const toUpdate = {
-    ...(slug !== undefined && { slug }),
-    ...(friendlyName !== undefined && { friendlyName }),
-    ...(parentId !== undefined && { parentId }),
-  };
+router.patch<Params>(
+  "/api/nouns/:nounId",
+  param("nounId").isInt().toInt(),
+  async (req, res) => {
+    const validationErrors = validationResult(req);
+    if (!validationErrors.isEmpty()) {
+      return invalidRequest(res, validationErrors);
+    }
 
-  const [numUpdated] = await sequelize.models.Noun.update(toUpdate, {
-    where: {
-      id: req.params.nounId,
-    },
-  });
+    const { slug, friendlyName, parentId } = req.body;
+    const toUpdate = {
+      ...(slug !== undefined && { slug }),
+      ...(friendlyName !== undefined && { friendlyName }),
+      ...(parentId !== undefined && { parentId }),
+    };
 
-  if (numUpdated === 0) {
-    res.sendStatus(404);
-  } else {
-    res.sendStatus(204);
+    const [numUpdated] = await sequelize.models.Noun.update(toUpdate, {
+      where: {
+        id: req.params.nounId,
+      },
+    });
+
+    if (numUpdated === 0) {
+      res.sendStatus(404);
+    } else {
+      res.sendStatus(204);
+    }
   }
-});
+);
+
+interface Params {
+  nounId: number;
+}

--- a/backend/nouns/PatchNouns.ts
+++ b/backend/nouns/PatchNouns.ts
@@ -1,7 +1,11 @@
 import { sequelize } from "../DB.js";
 import { router } from "../Router.js";
 import { param, validationResult } from "express-validator";
-import { invalidRequest } from "../Utils/EndpointResponses.js";
+import {
+  invalidRequest,
+  notFound,
+  successNoContent,
+} from "../Utils/EndpointResponses.js";
 
 router.patch<Params>(
   "/api/nouns/:nounId",
@@ -26,9 +30,9 @@ router.patch<Params>(
     });
 
     if (numUpdated === 0) {
-      res.sendStatus(404);
+      notFound(res, `No such noun with id '${req.params.nounId}'`);
     } else {
-      res.sendStatus(204);
+      successNoContent(res);
     }
   }
 );

--- a/backend/nouns/PostNouns.ts
+++ b/backend/nouns/PostNouns.ts
@@ -6,9 +6,9 @@ import { router } from "../Router.js";
 
 router.post(
   "/api/nouns",
-  body("tableName").isString().notEmpty(),
-  body("slug").isString().notEmpty(),
-  body("friendlyName").isString().notEmpty(),
+  body("tableName").isString().notEmpty().trim(),
+  body("slug").isString().notEmpty().trim(),
+  body("friendlyName").isString().notEmpty().trim(),
   body("parentId").isInt().optional({ nullable: true }),
   async (req, res) => {
     const validationErrors = validationResult(req);


### PR DESCRIPTION
This adds express-validator's validation and sanitization to all endpoints. Also switches over to using an EndpointUtils.ts file for common responses.