### PR TITLE
Repeatedly attempt to connect to db during startup.

### DIFF
--- a/backend/DB.ts
+++ b/backend/DB.ts
@@ -40,7 +40,7 @@ export const dbReady = new Promise<void>((resolve, reject) => {
       })
       .catch((err) => {
         console.error("Failed to connect to db. Trying again in 100ms");
-        console.error(err);
+        // console.error(err);
       });
   }, 100);
 });

--- a/backend/DB.ts
+++ b/backend/DB.ts
@@ -13,8 +13,9 @@ export const sequelize: SequelizeType = db.sequelize;
 export const dbReady = new Promise<void>((resolve, reject) => {
   const intervalId = setInterval(() => {
     console.log("Attempting to connect to db");
-    sequelize.authenticate().then(
-      () => {
+    sequelize
+      .authenticate()
+      .then(() => {
         console.log("Database connection established");
         clearInterval(intervalId);
 
@@ -36,11 +37,11 @@ export const dbReady = new Promise<void>((resolve, reject) => {
           console.log("Finished database migrations");
           resolve();
         });
-      },
-      (err) => {
-        reject(err);
-      }
-    );
+      })
+      .catch((err) => {
+        console.error("Failed to connect to db. Trying again in 100ms");
+        console.error(err);
+      });
   }, 100);
 });
 


### PR DESCRIPTION
Previously the backend code would re-attempt to connect to the database if it started up before the database was ready for connections. That behavior was lost somewhere along the way, which meant that if you ran `pnpm run develop` the backend would sometimes just completely die and not work until you restarted. The preferred behavior is to continue attempting to connect on an interval so that it doesn't matter if develop:backend starts up before develop:db. This pull request reinstates that behavior.