### PR TITLE
Faster startup time for backend dev server

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "develop": "concurrently \"pnpm:develop:*\"",
     "dev:vscode": "concurrently \"pnpm:develop:db\" \"pnpm:develop:frontend\"",
     "develop:backend": "cross-env \"NODE_OPTIONS=--experimental-loader ts-node/esm  --experimental-specifier-resolution=node\" IS_RUNNING_LOCALLY=true nodemon --signal SIGINT backend/Server.ts --watch backend --watch migrations --watch frontend --ext tsx,ts,js",
+    "develop:backend:types": "tsc --noEmit --watch",
     "develop:db": "docker-compose up",
     "develop:frontend": "webpack serve --config webpack.config.cjs --port 7700",
     "check-format": "prettier --check .",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "files": ["backend/Server.ts"],
   "compilerOptions": {
     "esModuleInterop": true,
     "module": "esnext",
@@ -17,5 +18,8 @@
       "es2016.array.include",
       "es2018"
     ]
+  },
+  "ts-node": {
+    "transpileOnly": true
   }
 }


### PR DESCRIPTION
The `transpileOnly` option in tsnode makes compilation significantly faster,  as type checking usually takes longer than compilation. See https://github.com/TypeStrong/ts-node#via-tsconfigjson-recommended for more info