### PR TITLE
Instruct tsc to not clear terminal output.

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "develop": "concurrently \"pnpm:develop:*\"",
     "dev:vscode": "concurrently \"pnpm:develop:db\" \"pnpm:develop:frontend\"",
     "develop:backend": "cross-env \"NODE_OPTIONS=--experimental-loader ts-node/esm  --experimental-specifier-resolution=node\" IS_RUNNING_LOCALLY=true nodemon --signal SIGINT backend/Server.ts --watch backend --watch migrations --watch frontend --ext tsx,ts,js",
-    "develop:backend:types": "tsc --noEmit --watch",
+    "develop:backend:types": "tsc --noEmit --watch --preserveWatchOutput",
     "develop:db": "docker-compose up",
     "develop:frontend": "webpack serve --config webpack.config.cjs --port 7700",
     "check-format": "prettier --check .",


### PR DESCRIPTION
See https://github.com/microsoft/TypeScript/pull/21303. This will make it easier to see what's going on across all the `develop:*` scripts.