### PR TITLE
Default HTTP Response for non-existent APIs.

### DIFF
--- a/backend/ApiNotFound.ts
+++ b/backend/ApiNotFound.ts
@@ -1,0 +1,5 @@
+import { router } from "./Router.js";
+
+router.use("/api", (req, res, next) => {
+  res.status(404).send("No such api");
+});

--- a/backend/RouteImports.ts
+++ b/backend/RouteImports.ts
@@ -7,5 +7,8 @@ import "./Nouns/PatchNouns.js";
 import "./Nouns/DeleteNouns.js";
 import "./Fields/BatchPostFields.js";
 
+// The default API Handler responds with a 404
+import "./ApiNotFound.js";
+
 // WebApp should be at the bottom, as it's the default route
 import "./WebApp/WebApp.js";


### PR DESCRIPTION
For all urls that start with `/api`, we should respond with an http 404 if the api doesn't exist. Before this PR, it was responding with a 200 and the web app's HTML