### PR TITLE
Implement <Icon> component

### DIFF
--- a/frontend/Styleguide/Button.tsx
+++ b/frontend/Styleguide/Button.tsx
@@ -20,17 +20,20 @@ export enum ButtonKind {
   secondary = "secondary",
   transparent = "transparent",
   classic = "classic",
+  icon = "icon",
 }
 
 export function buttonClasses(kind: ButtonKind, extraClassName: string = "") {
   const kindClasses = buttonKindClasses[kind] || "";
   return always(kindClasses)
     .always(extraClassName)
-    .maybe(styledButtonClasses, kind !== ButtonKind.classic)
+    .maybe(styledButtonClasses, styledButtonKinds.includes(kind))
     .toString();
 }
 
 const styledButtonClasses = `flex items-center justify-center cursor-pointer py-2.5 px-5 rounded font-medium`;
+
+const styledButtonKinds = [ButtonKind.primary, ButtonKind.secondary];
 
 const buttonKindClasses = {
   [ButtonKind.primary]: "bg-primary text-white",
@@ -39,4 +42,6 @@ const buttonKindClasses = {
   [ButtonKind.transparent]: "text-primary hover:text-primary",
   [ButtonKind.classic]:
     "text-primary underline hover:text-primary hover:underline",
+  [ButtonKind.icon]:
+    "text-primary hover:bg-gray-200 flex justify-items-center align-items-center p-2 rounded",
 };

--- a/frontend/Styleguide/Icon.test.tsx
+++ b/frontend/Styleguide/Icon.test.tsx
@@ -5,13 +5,27 @@ import { Icon, IconVariant } from "./Icon";
 describe("<Icon />", () => {
   it(`always renders a <title>`, () => {
     Object.keys(IconVariant).forEach((iconVariant) => {
-      const w = render(<Icon variant={IconVariant.close} />);
+      const w = render(<Icon variant={iconVariant} />);
 
       expect(w.baseElement.querySelector("title")).toBeInTheDocument();
 
-      w.rerender(<Icon variant={IconVariant.close} alt="Donkey Kong" />);
+      w.rerender(<Icon variant={iconVariant} alt="Donkey Kong" />);
 
       expect(w.queryByTitle("Donkey Kong")).toBeInTheDocument();
+    });
+  });
+
+  it(`respects the size prop`, () => {
+    Object.keys(IconVariant).forEach((iconVariant) => {
+      const w = render(<Icon variant={iconVariant} alt="the image" />);
+      let svgEl = w.getByTitle("the image").parentElement;
+      expect(svgEl.getAttribute("height")).toBe(`16px`);
+      expect(svgEl.getAttribute("width")).toBe(`16px`);
+
+      w.rerender(<Icon variant={iconVariant} alt="the image" size={26} />);
+      svgEl = w.getByTitle("the image").parentElement;
+      expect(svgEl.getAttribute("height")).toBe(`26px`);
+      expect(svgEl.getAttribute("width")).toBe(`26px`);
     });
   });
 });

--- a/frontend/Styleguide/Icon.test.tsx
+++ b/frontend/Styleguide/Icon.test.tsx
@@ -1,0 +1,17 @@
+import { render } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { Icon, IconVariant } from "./Icon";
+
+describe("<Icon />", () => {
+  it(`always renders a <title>`, () => {
+    Object.keys(IconVariant).forEach((iconVariant) => {
+      const w = render(<Icon variant={IconVariant.close} />);
+
+      expect(w.baseElement.querySelector("title")).toBeInTheDocument();
+
+      w.rerender(<Icon variant={IconVariant.close} alt="Donkey Kong" />);
+
+      expect(w.queryByTitle("Donkey Kong")).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/Styleguide/Icon.tsx
+++ b/frontend/Styleguide/Icon.tsx
@@ -1,0 +1,44 @@
+export function Icon({ variant, size = 16, alt }: IconProps) {
+  const IconComponent: React.FunctionComponent<SpecificIconProps> =
+    IconComponents[variant];
+
+  if (!IconComponent) {
+    throw Error(`Unknown IconVariant '${variant}'`);
+  }
+
+  return <IconComponent size={size} alt={alt} />;
+}
+
+export interface IconProps {
+  variant: string;
+  alt?: string;
+  size?: number;
+}
+
+type SpecificIconProps = Omit<IconProps, "variant">;
+
+export enum IconVariant {
+  close = "close",
+}
+
+const IconComponents = {
+  [IconVariant.close]: CloseIcon,
+};
+
+export function CloseIcon({ size, alt }: SpecificIconProps) {
+  return (
+    <svg
+      height={size + "px"}
+      width={size + "px"}
+      id="Layer_1"
+      version="1.1"
+      viewBox={`0 0 512 512`}
+      xmlSpace="preserve"
+      xmlns="http://www.w3.org/2000/svg"
+      xmlnsXlink="http://www.w3.org/1999/xlink"
+    >
+      <title>{alt ?? "Close Icon"}</title>
+      <path d="M443.6,387.1L312.4,255.4l131.5-130c5.4-5.4,5.4-14.2,0-19.6l-37.4-37.6c-2.6-2.6-6.1-4-9.8-4c-3.7,0-7.2,1.5-9.8,4  L256,197.8L124.9,68.3c-2.6-2.6-6.1-4-9.8-4c-3.7,0-7.2,1.5-9.8,4L68,105.9c-5.4,5.4-5.4,14.2,0,19.6l131.5,130L68.4,387.1  c-2.6,2.6-4.1,6.1-4.1,9.8c0,3.7,1.4,7.2,4.1,9.8l37.4,37.6c2.7,2.7,6.2,4.1,9.8,4.1c3.5,0,7.1-1.3,9.8-4.1L256,313.1l130.7,131.1  c2.7,2.7,6.2,4.1,9.8,4.1c3.5,0,7.1-1.3,9.8-4.1l37.4-37.6c2.6-2.6,4.1-6.1,4.1-9.8C447.7,393.2,446.2,389.7,443.6,387.1z" />
+    </svg>
+  );
+}

--- a/frontend/Styleguide/Modal.test.tsx
+++ b/frontend/Styleguide/Modal.test.tsx
@@ -24,7 +24,7 @@ describe(`<Modal />`, () => {
     const w = render(<Modal title="Sample Header" close={close} />);
     expect(close).not.toHaveBeenCalled();
     fireEvent(
-      await w.findByText("\u2716"),
+      await w.findByTitle("Close Modal Icon"),
       new MouseEvent("click", {
         bubbles: true,
         cancelable: true,

--- a/frontend/Styleguide/Modal.tsx
+++ b/frontend/Styleguide/Modal.tsx
@@ -1,5 +1,6 @@
 import { HTMLProps } from "react";
 import { Button, ButtonKind } from "./Button";
+import { Icon, IconVariant } from "./Icon";
 
 export function Modal(props: ModalProps) {
   return (
@@ -13,12 +14,8 @@ export function Modal(props: ModalProps) {
       >
         <header className="flex items-center justify-between mb-2">
           <h1 className="text-xl">{props.title}</h1>
-          <Button
-            kind={ButtonKind.transparent}
-            onClick={props.close}
-            className="hover:bg-gray-200"
-          >
-            {"\u2716"}
+          <Button kind={ButtonKind.icon} onClick={props.close}>
+            <Icon variant={IconVariant.close} alt="Close Modal Icon" />
           </Button>
         </header>
         <div className="pt-5">{props.children}</div>


### PR DESCRIPTION
The temporary Icon i was using looked weird due to padding of the special close character. We'll need icons eventually, so I added the close icon as the first and established the pattern for adding more. I prefer doing icons with React <svg> rather than icon fonts because of the better control over sizing, fill color, etc.